### PR TITLE
add in-solidarity bot

### DIFF
--- a/.github/in-solidarity.yml
+++ b/.github/in-solidarity.yml
@@ -1,0 +1,9 @@
+---
+# https://github.com/jpoehnelt/in-solidarity-bot
+
+#rules:
+#  master:
+#    level: off  
+
+ignore:
+ - ".github/in-solidarity.yml"  # default


### PR DESCRIPTION
# In Solidarity bot

As referenced in #27, this is to setup the [In Solidarity bot](https://probot.github.io/apps/in-solidarity/) which lints for non-inclusive language (i.e. "master", "grandfathered", etc.)

The [docs](https://github.com/jpoehnelt/in-solidarity-bot/blob/main/docs/README.md) cover advanced use of the yml config, but the defaults should suffice for now. In addition to the settings yml in this pull request, an admin on the repo will need to install the bot:

1. Click "Add to Github" from the [bot home page](https://probot.github.io/apps/in-solidarity/)
2. Grant it read permissions to the repository



