### PR TITLE
add discussion template

### DIFF
--- a/.github/ISSUE_TEMPLATE/discussion.md
+++ b/.github/ISSUE_TEMPLATE/discussion.md
@@ -1,0 +1,7 @@
+---
+name: Discussion
+about: To create a discussion, please use https://github.com/sqlcollaborative/DataSaturdays/discussions
+---
+
+Please use [Github Discussions](https://github.com/sqlcollaborative/DataSaturdays/discussions) for topics
+that need broad input and cannot be addressed directly by a pull request. 


### PR DESCRIPTION
To help herd people away from using Issues when Discussions is the appropriate place. Since this is a new feature, people may not be used to it yet.

Resolves  #61 