### PR TITLE
Consistency Update

### DIFF
--- a/_posts/2021-04-17-datasaturday0005.md
+++ b/_posts/2021-04-17-datasaturday0005.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Data Saturday 05 - Redmond"
+title: "Data Saturday #5 - Redmond"
 subtitle: "Data Saturdays"
 tags: [test]
 comments: false

--- a/_posts/2021-04-24-datasaturday0006.md
+++ b/_posts/2021-04-24-datasaturday0006.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Data Saturday #06 - Malta"
+title: "Data Saturday #6 - Malta"
 subtitle: "Data Saturdays"
 tags: [test]
 comments: false

--- a/_posts/2021-05-15-datasaturday0004.md
+++ b/_posts/2021-05-15-datasaturday0004.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Data Saturday 03 - Johannesburg"
+title: "Data Saturday #4 - Johannesburg"
 subtitle: "Data Saturdays"
 tags: [test]
 comments: false


### PR DESCRIPTION
Events had numbers inconsistently shown. some had #, some not, some 2 digits, some not.

I started a standard, based on past events of Data Saturday #x - yyyy