### PR TITLE
so that existing event URLs still work

### DIFF
--- a/events/datasaturday0001.html
+++ b/events/datasaturday0001.html
@@ -1,0 +1,7 @@
+<html>
+<head>
+<meta http-equiv="Refresh" content="0; url='https://datasaturdays.com/2021-02-21-datasaturday0001/'" />
+</head>
+<body>Page has moved to <ahref="https://datasaturdays.com/2021-02-21-datasaturday0001/">https://datasaturdays.com/2021-02-21-datasaturday0001/</a>
+</body>
+</html>

--- a/events/datasaturday0001.html
+++ b/events/datasaturday0001.html
@@ -2,6 +2,6 @@
 <head>
 <meta http-equiv="Refresh" content="0; url='https://datasaturdays.com/2021-02-21-datasaturday0001/'" />
 </head>
-<body>Page has moved to <ahref="https://datasaturdays.com/2021-02-21-datasaturday0001/">https://datasaturdays.com/2021-02-21-datasaturday0001/</a>
+<body>Page has moved to <a href="https://datasaturdays.com/2021-02-21-datasaturday0001/">https://datasaturdays.com/2021-02-21-datasaturday0001/</a>
 </body>
 </html>

--- a/events/datasaturday0002.html
+++ b/events/datasaturday0002.html
@@ -2,6 +2,6 @@
 <head>
 <meta http-equiv="Refresh" content="0; url='https://datasaturdays.com/2021-01-23-datasaturday0002/'" />
 </head>
-<body>Page has moved to <ahref="https://datasaturdays.com/2021-01-23-datasaturday0002/">https://datasaturdays.com/2021-01-23-datasaturday0002/</a>
+<body>Page has moved to <a href="https://datasaturdays.com/2021-01-23-datasaturday0002/">https://datasaturdays.com/2021-01-23-datasaturday0002/</a>
 </body>
 </html>

--- a/events/datasaturday0002.html
+++ b/events/datasaturday0002.html
@@ -1,0 +1,7 @@
+<html>
+<head>
+<meta http-equiv="Refresh" content="0; url='https://datasaturdays.com/2021-01-23-datasaturday0002/'" />
+</head>
+<body>Page has moved to <ahref="https://datasaturdays.com/2021-01-23-datasaturday0002/">https://datasaturdays.com/2021-01-23-datasaturday0002/</a>
+</body>
+</html>

--- a/events/datasaturday0003.html
+++ b/events/datasaturday0003.html
@@ -2,6 +2,6 @@
 <head>
 <meta http-equiv="Refresh" content="0; url='https://datasaturdays.com/2021-03-27-datasaturday0003/'" />
 </head>
-<body>Page has moved to <ahref="https://datasaturdays.com/2021-03-27-datasaturday0003/">https://datasaturdays.com/2021-03-27-datasaturday0003/</a>
+<body>Page has moved to <a href="https://datasaturdays.com/2021-03-27-datasaturday0003/">https://datasaturdays.com/2021-03-27-datasaturday0003/</a>
 </body>
 </html>

--- a/events/datasaturday0004.html
+++ b/events/datasaturday0004.html
@@ -2,6 +2,6 @@
 <head>
 <meta http-equiv="Refresh" content="0; url='https://datasaturdays.com/2021-05-15-datasaturday0004/'" />
 </head>
-<body>Page has moved to <ahref="https://datasaturdays.com/2021-05-15-datasaturday0004/">https://2021-05-15-datasaturday0004/</a>
+<body>Page has moved to <a href="https://datasaturdays.com/2021-05-15-datasaturday0004/">https://2021-05-15-datasaturday0004/</a>
 </body>
 </html>

--- a/events/datasaturday0004.html
+++ b/events/datasaturday0004.html
@@ -1,0 +1,7 @@
+<html>
+<head>
+<meta http-equiv="Refresh" content="0; url='https://datasaturdays.com/2021-05-15-datasaturday0004/'" />
+</head>
+<body>Page has moved to <ahref="https://datasaturdays.com/2021-05-15-datasaturday0004/">https://2021-05-15-datasaturday0004/</a>
+</body>
+</html>

--- a/events/datasaturday0005.html
+++ b/events/datasaturday0005.html
@@ -2,6 +2,6 @@
 <head>
 <meta http-equiv="Refresh" content="0; url='https://datasaturdays.com/2021-04-17-datasaturday0005/'" />
 </head>
-<body>Page has moved to <ahref="https://datasaturdays.com/2021-04-17-datasaturday0005/">https://datasaturdays.com/2021-04-17-datasaturday0005/</a>
+<body>Page has moved to <a href="https://datasaturdays.com/2021-04-17-datasaturday0005/">https://datasaturdays.com/2021-04-17-datasaturday0005/</a>
 </body>
 </html>

--- a/events/datasaturday0005.html
+++ b/events/datasaturday0005.html
@@ -1,0 +1,7 @@
+<html>
+<head>
+<meta http-equiv="Refresh" content="0; url='https://datasaturdays.com/2021-04-17-datasaturday0005/'" />
+</head>
+<body>Page has moved to <ahref="https://datasaturdays.com/2021-04-17-datasaturday0005/">https://datasaturdays.com/2021-04-17-datasaturday0005/</a>
+</body>
+</html>

--- a/events/datasaturday0006.html
+++ b/events/datasaturday0006.html
@@ -2,6 +2,6 @@
 <head>
 <meta http-equiv="Refresh" content="0; url='https://datasaturdays.com/2021-04-24-datasaturday0006/'" />
 </head>
-<body>Page has moved to <ahref="https://datasaturdays.com/2021-04-24-datasaturday0006/">https://datasaturdays.com/2021-04-24-datasaturday0006/</a>
+<body>Page has moved to <a href="https://datasaturdays.com/2021-04-24-datasaturday0006/">https://datasaturdays.com/2021-04-24-datasaturday0006/</a>
 </body>
 </html>

--- a/events/datasaturday0006.html
+++ b/events/datasaturday0006.html
@@ -1,0 +1,7 @@
+<html>
+<head>
+<meta http-equiv="Refresh" content="0; url='https://datasaturdays.com/2021-04-24-datasaturday0006/'" />
+</head>
+<body>Page has moved to <ahref="https://datasaturdays.com/2021-04-24-datasaturday0006/">https://datasaturdays.com/2021-04-24-datasaturday0006/</a>
+</body>
+</html>

--- a/events/datasaturday0007.html
+++ b/events/datasaturday0007.html
@@ -2,6 +2,6 @@
 <head>
 <meta http-equiv="Refresh" content="0; url='https://datasaturdays.com/2021-06-12-datasaturday0007/'" />
 </head>
-<body>Page has moved to <ahref="https://datasaturdays.com/2021-06-12-datasaturday0007/">https://datasaturdays.com/2021-06-12-datasaturday0007/</a>
+<body>Page has moved to <a href="https://datasaturdays.com/2021-06-12-datasaturday0007/">https://datasaturdays.com/2021-06-12-datasaturday0007/</a>
 </body>
 </html>

--- a/events/datasaturday0007.html
+++ b/events/datasaturday0007.html
@@ -1,0 +1,7 @@
+<html>
+<head>
+<meta http-equiv="Refresh" content="0; url='https://datasaturdays.com/2021-06-12-datasaturday0007/'" />
+</head>
+<body>Page has moved to <ahref="https://datasaturdays.com/2021-06-12-datasaturday0007/">https://datasaturdays.com/2021-06-12-datasaturday0007/</a>
+</body>
+</html>

--- a/events/datasaturday0008.html
+++ b/events/datasaturday0008.html
@@ -1,0 +1,7 @@
+<html>
+<head>
+<meta http-equiv="Refresh" content="0; url='https://datasaturdays.com/2021-05-15-datasaturday0008/'" />
+</head>
+<body>Page has moved to <ahref="https://datasaturdays.com/2021-05-15-datasaturday0008/">https://datasaturdays.com/2021-05-15-datasaturday0008/</a>
+</body>
+</html>

--- a/events/datasaturday0008.html
+++ b/events/datasaturday0008.html
@@ -2,6 +2,6 @@
 <head>
 <meta http-equiv="Refresh" content="0; url='https://datasaturdays.com/2021-05-15-datasaturday0008/'" />
 </head>
-<body>Page has moved to <ahref="https://datasaturdays.com/2021-05-15-datasaturday0008/">https://datasaturdays.com/2021-05-15-datasaturday0008/</a>
+<body>Page has moved to <a href="https://datasaturdays.com/2021-05-15-datasaturday0008/">https://datasaturdays.com/2021-05-15-datasaturday0008/</a>
 </body>
 </html>

--- a/events/datasaturday0009.html
+++ b/events/datasaturday0009.html
@@ -2,6 +2,6 @@
 <head>
 <meta http-equiv="Refresh" content="0; url='https://datasaturdays.com/2021-06-12-datasaturday0009/'" />
 </head>
-<body>Page has moved to <ahref="https://datasaturdays.com/2021-06-12-datasaturday0009/">https://datasaturdays.com/2021-06-12-datasaturday0009/</a>
+<body>Page has moved to <a href="https://datasaturdays.com/2021-06-12-datasaturday0009/">https://datasaturdays.com/2021-06-12-datasaturday0009/</a>
 </body>
 </html>

--- a/events/datasaturday0009.html
+++ b/events/datasaturday0009.html
@@ -1,0 +1,7 @@
+<html>
+<head>
+<meta http-equiv="Refresh" content="0; url='https://datasaturdays.com/2021-06-12-datasaturday0009/'" />
+</head>
+<body>Page has moved to <ahref="https://datasaturdays.com/2021-06-12-datasaturday0009/">https://datasaturdays.com/2021-06-12-datasaturday0009/</a>
+</body>
+</html>

--- a/events/datasaturday0010.html
+++ b/events/datasaturday0010.html
@@ -2,6 +2,6 @@
 <head>
 <meta http-equiv="Refresh" content="0; url='https://datasaturdays.com/2021-10-09-datasaturday0010/'" />
 </head>
-<body>Page has moved to <ahref="https://datasaturdays.com/2021-10-09-datasaturday0010/">https://datasaturdays.com/2021-10-09-datasaturday0010/</a>
+<body>Page has moved to <a href="https://datasaturdays.com/2021-10-09-datasaturday0010/">https://datasaturdays.com/2021-10-09-datasaturday0010/</a>
 </body>
 </html>

--- a/events/datasaturday0010.html
+++ b/events/datasaturday0010.html
@@ -1,0 +1,7 @@
+<html>
+<head>
+<meta http-equiv="Refresh" content="0; url='https://datasaturdays.com/2021-10-09-datasaturday0010/'" />
+</head>
+<body>Page has moved to <ahref="https://datasaturdays.com/2021-10-09-datasaturday0010/">https://datasaturdays.com/2021-10-09-datasaturday0010/</a>
+</body>
+</html>


### PR DESCRIPTION
WE don't want to break existing links, so for current created events we can use the redirect