### PR TITLE
Adding basic RSS feed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,18 +28,17 @@ round-avatar: true
 # then specify the following parameter
 #title-img: /path/to/image
 
-
 # --- Footer social media links --- #
 
 # Select the social network links that you want to show in the footer.
 # Uncomment the links you want to show and add your information to each one.
 social-network-links:
   email: "support@datasaturdays.com"
- # facebook: datasaturdays
+#  facebook: datasaturdays
   github: sqlcollaborative/datasaturdays
   twitter: datasaturdays
- # patreon: 
- # youtube: yourname
+#  patreon: 
+#  youtube: yourname
 #  medium: yourname
 #  reddit: yourname
 #  linkedin: yourname
@@ -60,7 +59,7 @@ social-network-links:
 
 # If you want to show a link to an RSS in the footer, add the site description here.
 # If you don't want to show an RSS link, remove the following line.
-# rss-description: This website is a virtual proof that I'm awesome
+rss-description: Data Saturdays RSS Feed
 
 # --- General options --- #
 
@@ -191,6 +190,9 @@ exclude:
 plugins:
   - jekyll-paginate
   - jekyll-sitemap
+  - jekyll-feed
 
 future: true
 
+feed:
+  posts_limit: 1000

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -25,6 +25,6 @@
     <!-- DataTables -->
     <link href=https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.1/css/bootstrap.css rel=stylesheet>
     <link href=https://cdn.datatables.net/1.10.23/css/dataTables.bootstrap4.min.css rel=stylesheet>
-
-
+    <!-- RSS feed -->
+    <link rel="alternate" type="application/atom+xml" title="{{ site.title }}" href="/feed.xml">
 </head>


### PR DESCRIPTION
Adds basic RSS feed support, with 1,000 maximum posts.

This is a rudimentary feature, and will require someone good at Jekyll and YAML to figure out why the `description` front matter isn't making it into the summary text. That person is not me.

The Atom RSS feed will be generated at `/feed.xml` and is readable by all the RSS feed readers I tested. Apparently it does not work with Outlook's built-in RSS reader.

Closes #214.